### PR TITLE
Implement push notification registration and lost/found alerts

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,11 +1,16 @@
 import { lightTheme } from '@/theme';
 import Toast, { toastConfig } from '@components/ui/Toast';
 import { ThemeProvider } from '@contexts/ThemeContext';
+import { useAuth } from '@hooks/useAuth';
+import { usePushNotifications } from '@hooks/usePushNotifications';
 import { Stack } from 'expo-router';
 import React from 'react';
 import { PaperProvider } from 'react-native-paper';
 
 export default function RootLayout() {
+  const { user } = useAuth();
+  usePushNotifications(user?.id);
+
   return (
     <PaperProvider theme={lightTheme}>
       <ThemeProvider>

--- a/hooks/usePushNotifications.ts
+++ b/hooks/usePushNotifications.ts
@@ -1,0 +1,47 @@
+import { useEffect } from 'react';
+import * as Notifications from 'expo-notifications';
+import * as Device from 'expo-device';
+import { Platform } from 'react-native';
+import { notificationsService } from '@services/notifications';
+import { showToast } from '@/components/ui/Toast';
+
+export function usePushNotifications(userId?: string) {
+  useEffect(() => {
+    if (!userId) return;
+
+    async function register() {
+      try {
+        if (!Device.isDevice) {
+          return;
+        }
+
+        const { status: existingStatus } = await Notifications.getPermissionsAsync();
+        let finalStatus = existingStatus;
+        if (existingStatus !== 'granted') {
+          const { status } = await Notifications.requestPermissionsAsync();
+          finalStatus = status;
+        }
+
+        if (finalStatus !== 'granted') {
+          showToast.error('Erro', 'Permissão de notificações negada');
+          return;
+        }
+
+        const tokenData = await Notifications.getExpoPushTokenAsync();
+        const token = tokenData.data;
+        await notificationsService.registerToken(token);
+
+        if (Platform.OS === 'android') {
+          await Notifications.setNotificationChannelAsync('default', {
+            name: 'default',
+            importance: Notifications.AndroidImportance.DEFAULT,
+          });
+        }
+      } catch (err) {
+        console.warn('Erro ao registrar notificações', err);
+      }
+    }
+
+    register();
+  }, [userId]);
+}

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "expo-status-bar": "~2.2.3",
     "expo-symbols": "~0.4.4",
     "expo-system-ui": "~5.0.7",
+    "expo-notifications": "~0.20.1",
     "expo-web-browser": "~14.1.6",
     "react": "19.0.0",
     "react-dom": "19.0.0",

--- a/services/notifications.ts
+++ b/services/notifications.ts
@@ -1,0 +1,11 @@
+import api from '@lib/axios';
+
+export const notificationsService = {
+  registerToken: async (token: string): Promise<void> => {
+    await api.post('/notifications/register', { token });
+  },
+
+  notifyNearbyUsers: async (postId: string): Promise<void> => {
+    await api.post('/notifications/nearby', { postId });
+  },
+};

--- a/services/posts.ts
+++ b/services/posts.ts
@@ -1,5 +1,6 @@
 import { Post } from '@/types/database';
 import api from '@lib/axios';
+import { notificationsService } from './notifications';
 
 export type PostFilters = {
   type?: 'LOST' | 'FOUND' | 'ADOPTION';
@@ -75,7 +76,15 @@ export const postsService = {
   async create(data: CreatePostData): Promise<Post> {
     try {
       const response = await api.post<Post>('/posts', data);
-      return response.data;
+      const post = response.data;
+
+      if (post.type === 'LOST' || post.type === 'FOUND') {
+        notificationsService.notifyNearbyUsers(post.id).catch(err => {
+          console.warn('Falha ao enviar notificação', err);
+        });
+      }
+
+      return post;
     } catch (error) {
       throw error;
     }


### PR DESCRIPTION
## Summary
- add `expo-notifications` dependency
- create notification service and hook
- register push notifications in layout
- notify nearby users when a lost or found post is created

## Testing
- `npm run lint` *(fails: expo not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f58a432f4832d8b4dcbaabced68cf