### PR TITLE
Create reusable MenuItem component

### DIFF
--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -1,8 +1,8 @@
-import { Ionicons } from '@expo/vector-icons';
+import { MenuItem } from '@/components/ui/MenuItem';
 import { useAuth } from '@hooks/useAuth';
 import { router } from 'expo-router';
 import React from 'react';
-import { ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 export default function Profile() {
@@ -45,63 +45,54 @@ export default function Profile() {
           <View style={styles.section}>
             <Text style={styles.sectionTitle}>Configurações</Text>
 
-            <TouchableOpacity 
-              style={styles.menuItem}
+            <MenuItem
+              leftIcon="person-outline"
+              label="Editar Perfil"
               onPress={() => router.push('/user/edit-profile')}
-            >
-              <Ionicons name="person-outline" size={24} color="#1a1a1a" />
-              <Text style={styles.menuItemText}>Editar Perfil</Text>
-              <Ionicons name="chevron-forward" size={24} color="#666" />
-            </TouchableOpacity>
+              rightIcon="chevron-forward"
+            />
 
-            <TouchableOpacity 
-              style={styles.menuItem}
+            <MenuItem
+              leftIcon="notifications-outline"
+              label="Notificações"
               onPress={() => router.push('/user/notifications')}
-            >
-              <Ionicons name="notifications-outline" size={24} color="#1a1a1a" />
-              <Text style={styles.menuItemText}>Notificações</Text>
-              <Ionicons name="chevron-forward" size={24} color="#666" />
-            </TouchableOpacity>
+              rightIcon="chevron-forward"
+            />
 
-            <TouchableOpacity 
-              style={styles.menuItem}
+            <MenuItem
+              leftIcon="lock-closed-outline"
+              label="Alterar Senha"
               onPress={() => router.push('/user/change-password' as any)}
-            >
-              <Ionicons name="lock-closed-outline" size={24} color="#1a1a1a" />
-              <Text style={styles.menuItemText}>Alterar Senha</Text>
-              <Ionicons name="chevron-forward" size={24} color="#666" />
-            </TouchableOpacity>
+              rightIcon="chevron-forward"
+            />
           </View>
 
           <View style={styles.section}>
             <Text style={styles.sectionTitle}>Sobre</Text>
 
-            <TouchableOpacity 
-              style={styles.menuItem}
+            <MenuItem
+              leftIcon="help-circle-outline"
+              label="Ajuda"
               onPress={() => router.push('/static/help')}
-            >
-              <Ionicons name="help-circle-outline" size={24} color="#1a1a1a" />
-              <Text style={styles.menuItemText}>Ajuda</Text>
-              <Ionicons name="chevron-forward" size={24} color="#666" />
-            </TouchableOpacity>
+              rightIcon="chevron-forward"
+            />
 
-            <TouchableOpacity 
-              style={styles.menuItem}
+            <MenuItem
+              leftIcon="information-circle-outline"
+              label="Termos de Uso"
               onPress={() => router.push('/static/terms')}
-            >
-              <Ionicons name="information-circle-outline" size={24} color="#1a1a1a" />
-              <Text style={styles.menuItemText}>Termos de Uso</Text>
-              <Ionicons name="chevron-forward" size={24} color="#666" />
-            </TouchableOpacity>
+              rightIcon="chevron-forward"
+            />
           </View>
 
-          <TouchableOpacity 
-            style={styles.logoutButton} 
+          <MenuItem
+            leftIcon="log-out-outline"
+            label="Sair"
             onPress={handleLogout}
-          >
-            <Ionicons name="log-out-outline" size={24} color="#FF3B30" />
-            <Text style={styles.logoutButtonText}>Sair</Text>
-          </TouchableOpacity>
+            style={styles.logoutButton}
+            labelStyle={styles.logoutButtonText}
+            leftIconColor="#FF3B30"
+          />
         </View>
       </ScrollView>
     </SafeAreaView>

--- a/app/pet/[id].tsx
+++ b/app/pet/[id].tsx
@@ -1,6 +1,6 @@
-import { PetImage } from '@/components/PetImage';
 import { PetDetailsSkeleton } from '@/components/skeletons/PetDetailsSkeleton';
 import { Header } from '@/components/ui/Header';
+import { ImageHeader } from '@/components/ui/ImageHeader';
 import { showToast } from '@/components/ui/Toast';
 import { Pet, PetGender, PetSize, PetType } from '@/types/database';
 import { getPetGenderLabel, getPetSizeLabel, getPetTypeLabel } from '@/utils/pet';
@@ -76,16 +76,12 @@ export default function PetDetails() {
     <SafeAreaView style={styles.container} edges={['top']}>
       <Header title="Detalhes do Pet" showBackButton />
       <ScrollView style={styles.content} contentContainerStyle={{ paddingBottom: 32 }}>
-        <View style={styles.imageWrapper}>
-          <PetImage pet={pet} />
-          <TouchableOpacity style={styles.closeButton} onPress={() => router.back()}>
-            <MaterialCommunityIcons name="close" size={28} color="#222" />
-          </TouchableOpacity>
-          <View style={styles.typeBadge}>
-            <MaterialCommunityIcons name="paw" size={16} color="#fff" />
-            <Text style={styles.typeBadgeText}>{getPetTypeLabel(pet.type as PetType)}</Text>
-          </View>
-        </View>
+        <ImageHeader
+          pet={pet}
+          onClose={() => router.back()}
+          badgeText={getPetTypeLabel(pet.type as PetType)}
+          badgeIcon="paw"
+        />
         <Text style={styles.petName}>{pet.name}</Text>
         <View style={styles.headerRow}>
           <View style={styles.badge}><Text style={styles.badgeText}>{pet.breed}</Text></View>
@@ -147,44 +143,6 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: '#fff',
-  },
-  imageWrapper: {
-    position: 'relative',
-    backgroundColor: '#eee',
-  },
-  image: {
-    width: '100%',
-    height: 260,
-    resizeMode: 'cover',
-    borderBottomLeftRadius: 24,
-    borderBottomRightRadius: 24,
-  },
-  closeButton: {
-    position: 'absolute',
-    top: 36,
-    right: 20,
-    backgroundColor: '#fff',
-    borderRadius: 20,
-    padding: 2,
-    elevation: 2,
-  },
-  typeBadge: {
-    position: 'absolute',
-    left: 20,
-    top: 36,
-    backgroundColor: '#3CB371',
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingHorizontal: 10,
-    paddingVertical: 4,
-    borderRadius: 12,
-    gap: 6,
-    elevation: 2,
-  },
-  typeBadgeText: {
-    color: '#fff',
-    fontWeight: 'bold',
-    fontSize: 14,
   },
   content: {
     flex: 1,

--- a/app/user/notifications.tsx
+++ b/app/user/notifications.tsx
@@ -1,4 +1,4 @@
-import { Ionicons } from '@expo/vector-icons';
+import { MenuItem } from '@/components/ui/MenuItem';
 import { useState } from 'react';
 import { ScrollView, StyleSheet, Switch, Text, View } from 'react-native';
 import { Header } from '@/components/ui/Header';
@@ -19,69 +19,69 @@ export default function Notifications() {
         <View style={styles.section}>
           <Text style={styles.sectionTitle}>Canais</Text>
 
-          <View style={styles.menuItem}>
-            <View style={styles.menuItemLeft}>
-              <Ionicons name="mail-outline" size={24} color="#1a1a1a" />
-              <Text style={styles.menuItemText}>Notificações por E-mail</Text>
-            </View>
-            <Switch
-              value={emailNotifications}
-              onValueChange={setEmailNotifications}
-              trackColor={{ false: '#ddd', true: '#007AFF' }}
-            />
-          </View>
+          <MenuItem
+            leftIcon="mail-outline"
+            label="Notificações por E-mail"
+            rightComponent={
+              <Switch
+                value={emailNotifications}
+                onValueChange={setEmailNotifications}
+                trackColor={{ false: '#ddd', true: '#007AFF' }}
+              />
+            }
+          />
 
-          <View style={styles.menuItem}>
-            <View style={styles.menuItemLeft}>
-              <Ionicons name="notifications-outline" size={24} color="#1a1a1a" />
-              <Text style={styles.menuItemText}>Notificações Push</Text>
-            </View>
-            <Switch
-              value={pushNotifications}
-              onValueChange={setPushNotifications}
-              trackColor={{ false: '#ddd', true: '#007AFF' }}
-            />
-          </View>
+          <MenuItem
+            leftIcon="notifications-outline"
+            label="Notificações Push"
+            rightComponent={
+              <Switch
+                value={pushNotifications}
+                onValueChange={setPushNotifications}
+                trackColor={{ false: '#ddd', true: '#007AFF' }}
+              />
+            }
+          />
         </View>
 
         <View style={styles.section}>
           <Text style={styles.sectionTitle}>Tipos de Notificação</Text>
 
-          <View style={styles.menuItem}>
-            <View style={styles.menuItemLeft}>
-              <Ionicons name="chatbubble-outline" size={24} color="#1a1a1a" />
-              <Text style={styles.menuItemText}>Novas Mensagens</Text>
-            </View>
-            <Switch
-              value={newMessages}
-              onValueChange={setNewMessages}
-              trackColor={{ false: '#ddd', true: '#007AFF' }}
-            />
-          </View>
+          <MenuItem
+            leftIcon="chatbubble-outline"
+            label="Novas Mensagens"
+            rightComponent={
+              <Switch
+                value={newMessages}
+                onValueChange={setNewMessages}
+                trackColor={{ false: '#ddd', true: '#007AFF' }}
+              />
+            }
+          />
 
-          <View style={styles.menuItem}>
-            <View style={styles.menuItemLeft}>
-              <Ionicons name="paw-outline" size={24} color="#1a1a1a" />
-              <Text style={styles.menuItemText}>Novos Pets</Text>
-            </View>
-            <Switch
-              value={newPets}
-              onValueChange={setNewPets}
-              trackColor={{ false: '#ddd', true: '#007AFF' }}
-            />
-          </View>
+          <MenuItem
+            leftIcon="paw-outline"
+            label="Novos Pets"
+            rightComponent={
+              <Switch
+                value={newPets}
+                onValueChange={setNewPets}
+                trackColor={{ false: '#ddd', true: '#007AFF' }}
+              />
+            }
+          />
 
-          <View style={styles.menuItem}>
-            <View style={styles.menuItemLeft}>
-              <Ionicons name="refresh-outline" size={24} color="#1a1a1a" />
-              <Text style={styles.menuItemText}>Atualizações do App</Text>
-            </View>
-            <Switch
-              value={updates}
-              onValueChange={setUpdates}
-              trackColor={{ false: '#ddd', true: '#007AFF' }}
-            />
-          </View>
+          <MenuItem
+            leftIcon="refresh-outline"
+            label="Atualizações do App"
+            rightComponent={
+              <Switch
+                value={updates}
+                onValueChange={setUpdates}
+                trackColor={{ false: '#ddd', true: '#007AFF' }}
+              />
+            }
+          />
         </View>
       </ScrollView>
     </Container>
@@ -105,22 +105,5 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     color: '#1a1a1a',
     marginBottom: 16,
-  },
-  menuItem: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    paddingVertical: 12,
-    borderBottomWidth: 1,
-    borderBottomColor: '#eee',
-  },
-  menuItemLeft: {
-    flexDirection: 'row',
-    alignItems: 'center',
-  },
-  menuItemText: {
-    fontSize: 16,
-    color: '#1a1a1a',
-    marginLeft: 12,
   },
 }); 

--- a/app/user/profile.tsx
+++ b/app/user/profile.tsx
@@ -1,10 +1,10 @@
 import { Container } from '@/components/ui/Container';
 import { Header } from '@/components/ui/Header';
-import { Ionicons } from '@expo/vector-icons';
+import { MenuItem } from '@/components/ui/MenuItem';
 import { useAuth } from '@hooks/useAuth';
 import { useRouter } from 'expo-router';
 import { useState } from 'react';
-import { Image, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { Image, ScrollView, StyleSheet, Text, View } from 'react-native';
 
 export default function Profile() {
   const router = useRouter();
@@ -52,43 +52,35 @@ export default function Profile() {
         </View>
 
         <View style={styles.menu}>
-          <TouchableOpacity
-            style={styles.menuItem}
+          <MenuItem
+            leftIcon="person-outline"
+            label="Editar Perfil"
             onPress={handleEditProfile}
-          >
-            <Ionicons name="person-outline" size={24} color="#666" />
-            <Text style={styles.menuText}>Editar Perfil</Text>
-            <Ionicons name="chevron-forward" size={24} color="#999" />
-          </TouchableOpacity>
+            rightIcon="chevron-forward"
+          />
 
-          <TouchableOpacity
-            style={styles.menuItem}
+          <MenuItem
+            leftIcon="document-text-outline"
+            label="Termos de Uso"
             onPress={() => router.push('/static/terms')}
-          >
-            <Ionicons name="document-text-outline" size={24} color="#666" />
-            <Text style={styles.menuText}>Termos de Uso</Text>
-            <Ionicons name="chevron-forward" size={24} color="#999" />
-          </TouchableOpacity>
+            rightIcon="chevron-forward"
+          />
 
-          <TouchableOpacity
-            style={styles.menuItem}
+          <MenuItem
+            leftIcon="help-circle-outline"
+            label="Ajuda"
             onPress={() => router.push('/static/help')}
-          >
-            <Ionicons name="help-circle-outline" size={24} color="#666" />
-            <Text style={styles.menuText}>Ajuda</Text>
-            <Ionicons name="chevron-forward" size={24} color="#999" />
-          </TouchableOpacity>
+            rightIcon="chevron-forward"
+          />
 
-          <TouchableOpacity
-            style={[styles.menuItem, styles.signOutButton]}
+          <MenuItem
+            leftIcon="log-out-outline"
+            label={loading ? 'Saindo...' : 'Sair'}
             onPress={handleSignOut}
-            disabled={loading}
-          >
-            <Ionicons name="log-out-outline" size={24} color="#FF3B30" />
-            <Text style={[styles.menuText, styles.signOutText]}>
-              {loading ? 'Saindo...' : 'Sair'}
-            </Text>
-          </TouchableOpacity>
+            style={styles.signOutButton}
+            labelStyle={styles.signOutText}
+            leftIconColor="#FF3B30"
+          />
         </View>
       </ScrollView>
     </Container>

--- a/components/ui/MenuItem.tsx
+++ b/components/ui/MenuItem.tsx
@@ -1,0 +1,54 @@
+import { Ionicons } from '@expo/vector-icons';
+import React from 'react';
+import { StyleSheet, Text, TouchableOpacity, View, ViewStyle, TextStyle } from 'react-native';
+
+interface MenuItemProps {
+  leftIcon: string;
+  label: string;
+  onPress?: () => void;
+  rightIcon?: string;
+  rightComponent?: React.ReactNode;
+  style?: ViewStyle;
+  labelStyle?: TextStyle;
+  leftIconColor?: string;
+  rightIconColor?: string;
+}
+
+export function MenuItem({
+  leftIcon,
+  label,
+  onPress,
+  rightIcon,
+  rightComponent,
+  style,
+  labelStyle,
+  leftIconColor = '#1a1a1a',
+  rightIconColor = '#666',
+}: MenuItemProps) {
+  const Container = onPress ? TouchableOpacity : View;
+
+  return (
+    <Container style={[styles.menuItem, style]} onPress={onPress as any} disabled={!onPress}>
+      <Ionicons name={leftIcon as any} size={24} color={leftIconColor} />
+      <Text style={[styles.menuText, labelStyle]}>{label}</Text>
+      {rightComponent}
+      {rightIcon && <Ionicons name={rightIcon as any} size={24} color={rightIconColor} />}
+    </Container>
+  );
+}
+
+const styles = StyleSheet.create({
+  menuItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 12,
+    borderBottomWidth: 1,
+    borderBottomColor: '#eee',
+  },
+  menuText: {
+    flex: 1,
+    fontSize: 16,
+    color: '#1a1a1a',
+    marginLeft: 12,
+  },
+});


### PR DESCRIPTION
## Summary
- add new MenuItem UI component
- refactor profile screens and notifications to use MenuItem
- reuse ImageHeader on pet details

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: expo not found)*


------
https://chatgpt.com/codex/tasks/task_e_683fa9e382a8832db5374d5bfaae8490